### PR TITLE
GPII-1170:  Restore tests for parameter handling in router paths...

### DIFF
--- a/tests/js/router/router-caseholder.js
+++ b/tests/js/router/router-caseholder.js
@@ -24,6 +24,11 @@ gpii.express.tests.router.caseHolder.verifyWildcard = function (response, body) 
     jqUnit.assertEquals("The nested body should match the configured content...", "Hello, wild world.", body);
 };
 
+gpii.express.tests.router.caseHolder.verifyParams = function (response, body) {
+    gpii.express.tests.helpers.isSaneResponse(jqUnit, response, body);
+
+    jqUnit.assertTrue("The response should contain the variable data...", body.indexOf("fooBar") !== -1);
+};
 
 // Wire in an instance of kettle.requests.request.http for each test and wire the check to its onError or onSuccess event
 fluid.defaults("gpii.express.tests.router.caseHolder", {
@@ -119,6 +124,20 @@ fluid.defaults("gpii.express.tests.router.caseHolder", {
                             args: ["{wildcardDeepRequest}.nativeResponse", "{arguments}.0"]
                         }
                     ]
+                },
+                {
+                    name: "Testing the 'params' router module...",
+                    type: "test",
+                    sequence: [
+                        {
+                            func: "{paramsRequest}.send"
+                        },
+                        {
+                            listener: "gpii.express.tests.router.caseHolder.verifyParams",
+                            event: "{paramsRequest}.events.onComplete",
+                            args: ["{paramsRequest}.nativeResponse", "{arguments}.0"]
+                        }
+                    ]
                 }
             ]
         }
@@ -194,6 +213,19 @@ fluid.defaults("gpii.express.tests.router.caseHolder", {
                     expander: {
                         funcName: "gpii.express.tests.helpers.assembleUrl",
                         args:     ["{testEnvironment}.options.baseUrl", "/wildcard/many/levels/deep"]
+                    }
+                },
+                port: "{testEnvironment}.options.port",
+                method: "GET"
+            }
+        },
+        paramsRequest: {
+            type: "kettle.test.request.http",
+            options: {
+                path: {
+                    expander: {
+                        funcName: "gpii.express.tests.helpers.assembleUrl",
+                        args:     ["{testEnvironment}.options.baseUrl", "/params/fooBar"]
                     }
                 },
                 port: "{testEnvironment}.options.port",

--- a/tests/js/router/router-tests.js
+++ b/tests/js/router/router-tests.js
@@ -86,6 +86,12 @@ fluid.defaults("gpii.express.tests.router.testEnvironment", {
                             message: "Hello, wild world."
                         }
                     },
+                    params: {
+                        type: "gpii.express.tests.router.params",
+                        options: {
+                            path: "/params/:myVar"
+                        }
+                    },
                     staticRouter: {
                         type: "gpii.express.router.static",
                         options: {

--- a/tests/js/router/test-router-params.js
+++ b/tests/js/router/test-router-params.js
@@ -6,13 +6,12 @@ fluid.registerNamespace("gpii.express.tests.router.params");
 
 gpii.express.tests.router.params.getRouter = function () {
     return function (req, res) {
-        res.status(200).send("Param is set to '" + req.params.myvar + "'...");
+        res.status(200).send("Param is set to '" + req.params.myVar + "'...");
     };
 };
 
 fluid.defaults("gpii.express.tests.router.params", {
     gradeNames: ["gpii.express.router", "autoInit"],
-    path:    "/params/:myvar",
     method: "get",
     invokers: {
         "getRouter": {


### PR DESCRIPTION
One of the core concepts of express is that of "parameters", portions of the request path that are actually variables.  This pull request restores the tests for this functionality.