### PR TITLE
GPII-1259: Fixed grunt dependencies to avoid problems when using `gpii-express` as a dependency.

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,3 +32,6 @@ require("./src/js/requestAware");
 
 // A convenience router that creates a request aware grade for each request
 require("./src/js/requestAwareRouter");
+
+// A convenience router to handle multiple content types from the same router.
+require("./src/js/contentAwareRouter");

--- a/package.json
+++ b/package.json
@@ -11,22 +11,22 @@
     "type": "git",
     "url":  "https://github.com/the-t-in-rtf/gpii-express"
   },
-  "author":   "Tony Atkins <tony@raisingthefloor.org>",
-  "license":  "See LICENSE file for details.",
-  "homepage": "https://github.com/the-t-in-rtf/gpii-express-couchuser-frontend",
+  "author":     "Tony Atkins <tony@raisingthefloor.org>",
+  "license":    "BSD-3-Clause",
+  "repository": "https://github.com/GPII/gpii-express",
   "dependencies": {
     "body-parser":             "1.10.2",
     "cookie-parser":           "1.3.3",
     "express-session":         "1.10.1",
     "express":                 "4.10.6",
+    "grunt":                   "~0.4.4",
+    "grunt-shell":             "0.6.4",
+    "grunt-contrib-jshint":    "~0.9.0",
+    "grunt-jsonlint":          "1.0.4",
+    "grunt-gpii":              "git://github.com/GPII/grunt-gpii.git#58ae055833f437a9e91baedb9f39a22c5fdd727f",
     "infusion":                "git://github.com/fluid-project/infusion.git#a930d31ca6430dad67566e712ccad5d333d74ddb"
   },
     "devDependencies": {
-      "grunt":                "~0.4.4",
-      "grunt-shell":          "0.6.4",
-      "grunt-contrib-jshint": "~0.9.0",
-      "grunt-jsonlint":       "1.0.4",
-      "grunt-gpii":           "git://github.com/GPII/grunt-gpii.git#58ae055833f437a9e91baedb9f39a22c5fdd727f",
       "jqUnit":               "git://github.com/fluid-project/node-jqUnit.git#d46bb932fa4069770852c51a92182939958f2d75",
       "kettle":               "git://github.com/fluid-project/kettle.git#e79bb81196df68c97eaa9f96c485a4321b69af75",
       "request":              "2.51.0"

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "Fluid components to model an express server and associated router modules.",
   "main":        "",
   "scripts": {
-    "test": "src/tests/all-tests.js"
+    "test":        "src/tests/all-tests.js",
+    "postinstall": "grunt dedupe-infusion"
   },
   "repository": {
     "type": "git",

--- a/src/js/contentAwareRouter.js
+++ b/src/js/contentAwareRouter.js
@@ -1,0 +1,64 @@
+// A router which delivers different types of content based on the content type.
+//
+// To use this grade, you are expected to provide `options.handlers`, with data as follows:
+//
+// handlers: {
+//   json: {
+//     contentType: "application/json",
+//     handler:     "{that}.jsonInvoker"
+//   },
+//   text: {
+//     contentType: "text",
+//     handler:     "{that}.textInvoker"
+//   }
+// }
+//
+// The `Accepts` headers supplied by the user will be tested using `request.accepts(contentType)`.  The first
+// `contentType` that matches will be used.  If no `Accepts` headers are provided, any contentType will match, and
+// hence the first handler will be used.   Thus, you should add handlers in the order you would prefer that they are
+// used.
+//
+"use strict";
+var fluid = fluid || require("infusion");
+var gpii  = fluid.registerNamespace("gpii");
+
+fluid.setLogging(true);
+require("./requestAwareRouter");
+
+fluid.registerNamespace("gpii.express.contentAware.request");
+gpii.express.contentAware.request.delegateToHandler = function (that) {
+    var handler = gpii.express.contentAware.request.firstMatchingHandler(that.request, that.options.handlers);
+    if (handler) {
+        handler(that.request, that.response);
+    }
+    else {
+        that.sendResponse(500, {ok: false, message: "Could not find an appropriate handler for the content types you accept."});
+    }
+};
+
+gpii.express.contentAware.request.firstMatchingHandler = function (request, handlers) {
+    var handler = null;
+    fluid.each(handlers, function (value) {
+        if (!handler && value.handler && value.contentType && request.accepts(value.contentType)) {
+            handler = value.handler;
+        }
+    });
+
+    return handler;
+};
+
+fluid.defaults("gpii.express.contentAware.request", {
+    gradeNames: ["gpii.express.requestAware"],
+    handlers: {},
+    listeners: {
+        "onCreate.delegateToHandler": {
+            funcName: "gpii.express.contentAware.request.delegateToHandler",
+            args:     ["{that}"]
+        }
+    }
+});
+
+fluid.defaults("gpii.express.contentAware.router", {
+    gradeNames:         ["gpii.express.requestAware.router", "autoInit"],
+    requestAwareGrades: ["gpii.express.contentAware.request"]
+});

--- a/src/js/contentAwareRouter.js
+++ b/src/js/contentAwareRouter.js
@@ -1,15 +1,15 @@
-// A router which delivers different types of content based on the content type.
+// A router which passes a request to different handlers based on the content type.
 //
 // To use this grade, you are expected to provide `options.handlers`, with data as follows:
 //
 // handlers: {
 //   json: {
 //     contentType: "application/json",
-//     handler:     "{that}.jsonInvoker"
+//     gradeNames:  "singleGrade"
 //   },
 //   text: {
-//     contentType: "text",
-//     handler:     "{that}.textInvoker"
+//     contentType: ["text/html", "text/plain"]
+//     gradeNames:  ["oneGrade", "anotherGrade"]
 //   }
 // }
 //
@@ -17,6 +17,10 @@
 // `contentType` that matches will be used.  If no `Accepts` headers are provided, any contentType will match, and
 // hence the first handler will be used.   Thus, you should add handlers in the order you would prefer that they are
 // used.
+//
+// When the decision has been made and a match has been found, a component with the list of supplied `gradeNames`
+// will be created to handle the request.  At least one of the gradeNames should extend the `requestAware.request`
+// grade, which is the base contract for this type of request delegation.
 //
 "use strict";
 var fluid = fluid || require("infusion");
@@ -29,7 +33,8 @@ fluid.registerNamespace("gpii.express.contentAware.request");
 gpii.express.contentAware.request.delegateToHandler = function (that) {
     var handler = gpii.express.contentAware.request.firstMatchingHandler(that.request, that.options.handlers);
     if (handler) {
-        handler(that.request, that.response);
+        // TODO: Construct the matching handler using `handler.gradeNames`.
+        //handler(that.request, that.response);
     }
     else {
         that.sendResponse(500, {ok: false, message: "Could not find an appropriate handler for the content types you accept."});
@@ -37,14 +42,13 @@ gpii.express.contentAware.request.delegateToHandler = function (that) {
 };
 
 gpii.express.contentAware.request.firstMatchingHandler = function (request, handlers) {
-    var handler = null;
     fluid.each(handlers, function (value) {
-        if (!handler && value.handler && value.contentType && request.accepts(value.contentType)) {
-            handler = value.handler;
+        if (value.handler && value.contentType && request.accepts(value.contentType)) {
+            return value.handler;
         }
     });
 
-    return handler;
+    return null;
 };
 
 fluid.defaults("gpii.express.contentAware.request", {

--- a/src/js/contentAwareRouter.js
+++ b/src/js/contentAwareRouter.js
@@ -58,7 +58,16 @@ gpii.express.contentAware.router.getRouter = function (that) {
 };
 
 fluid.defaults("gpii.express.contentAware.router", {
-    gradeNames:         ["gpii.express.router", "autoInit"],
+    gradeNames: ["gpii.express.router", "autoInit"],
+    // Our child handlers will be asked to handle requests outside of the normal routing mechanism.
+    // The next few lines are required to prevent routers whose `path` is `/` from hiding our own response.
+    nonsensePath: "/gibberish",
+    distributeOptions: [
+        {
+            source: "{that}.options.nonsensePath",
+            target: "{that > gpii.express.router}.options.path"
+        }
+    ],
     invokers: {
         getRouter: {
             funcName: "gpii.express.contentAware.router.getRouter",

--- a/src/js/contentAwareRouter.js
+++ b/src/js/contentAwareRouter.js
@@ -1,15 +1,19 @@
-// A router which passes a request to different handlers based on the content type.
+// A router which passes a request to different handlers based on the content type.  A handler is itself an
+// `RequestAwareRouter`, and will construct whatever components are needed to handle the underlying request.
 //
-// To use this grade, you are expected to provide `options.handlers`, with data as follows:
+// To use this grade, you must:
+//
+// 1. Add each `RequestAwareRouter` grade you need to your components.
+// 2. Create a map indicating which content types should be handled by which router, as in:
 //
 // handlers: {
 //   json: {
 //     contentType: "application/json",
-//     gradeNames:  "singleGrade"
+//     handler:     "{that}.component1"
 //   },
 //   text: {
 //     contentType: ["text/html", "text/plain"]
-//     gradeNames:  ["oneGrade", "anotherGrade"]
+//     handler:     "{that}.component2"
 //   }
 // }
 //
@@ -18,51 +22,51 @@
 // hence the first handler will be used.   Thus, you should add handlers in the order you would prefer that they are
 // used.
 //
-// When the decision has been made and a match has been found, a component with the list of supplied `gradeNames`
-// will be created to handle the request.  At least one of the gradeNames should extend the `requestAware.request`
-// grade, which is the base contract for this type of request delegation.
+// When the decision has been made and a match has been found, the request will be serviced by the
+// appropriate `RequestAwareRouter` component.
 //
 "use strict";
 var fluid = fluid || require("infusion");
 var gpii  = fluid.registerNamespace("gpii");
 
-fluid.setLogging(true);
 require("./requestAwareRouter");
 
-fluid.registerNamespace("gpii.express.contentAware.request");
-gpii.express.contentAware.request.delegateToHandler = function (that) {
-    var handler = gpii.express.contentAware.request.firstMatchingHandler(that.request, that.options.handlers);
+fluid.registerNamespace("gpii.express.contentAware.router");
+gpii.express.contentAware.router.delegateToHandler = function (that, request, response) {
+    var handler = gpii.express.contentAware.router.firstMatchingHandler(that, request, that.options.handlers);
     if (handler) {
-        // TODO: Construct the matching handler using `handler.gradeNames`.
-        //handler(that.request, that.response);
+        handler.events.onRequest.fire(request, response);
     }
     else {
-        that.sendResponse(500, {ok: false, message: "Could not find an appropriate handler for the content types you accept."});
+        response.status(500).send({ok: false, message: "Could not find an appropriate handler for the content types you accept."});
     }
 };
 
-gpii.express.contentAware.request.firstMatchingHandler = function (request, handlers) {
+gpii.express.contentAware.router.firstMatchingHandler = function (that, request, handlers) {
+    var handler = null;
     fluid.each(handlers, function (value) {
-        if (value.handler && value.contentType && request.accepts(value.contentType)) {
-            return value.handler;
+        if (!handler && value.handler && value.contentType && Boolean(request.accepts(value.contentType))) {
+            handler = value.handler;
         }
     });
 
-    return null;
+    return handler;
 };
 
-fluid.defaults("gpii.express.contentAware.request", {
-    gradeNames: ["gpii.express.requestAware"],
-    handlers: {},
-    listeners: {
-        "onCreate.delegateToHandler": {
-            funcName: "gpii.express.contentAware.request.delegateToHandler",
-            args:     ["{that}"]
-        }
-    }
-});
+gpii.express.contentAware.router.getRouter = function (that) {
+    return that.delegateToHandler;
+};
 
 fluid.defaults("gpii.express.contentAware.router", {
-    gradeNames:         ["gpii.express.requestAware.router", "autoInit"],
-    requestAwareGrades: ["gpii.express.contentAware.request"]
+    gradeNames:         ["gpii.express.router", "autoInit"],
+    invokers: {
+        getRouter: {
+            funcName: "gpii.express.contentAware.router.getRouter",
+            args:     ["{that}"]
+        },
+        delegateToHandler: {
+            funcName: "gpii.express.contentAware.router.delegateToHandler",
+            args: ["{that}", "{arguments}.0", "{arguments}.1"]
+        }
+    }
 });

--- a/src/js/requestAware.js
+++ b/src/js/requestAware.js
@@ -3,18 +3,33 @@
 //
 // http://docs.fluidproject.org/infusion/development/SubcomponentDeclaration.html#dynamic-subcomponents-with-a-source-event
 //
-// Typically, a gpii.express.router module would be constructing one of these components per request.  For more examples,
-// check out the tests.
+// Typically, a gpii.express.router module would be constructing one of these components per request.  Note that these
+// components are not persisted.  Any data you wish to retain should be passed on to a parent component such as the
+// `requestAware.router` that is creating the object.
 //
-// This module expects to be passed two things when it is constructed:
-// 1. The express request object.
-// 2. The express response object.
+// This grade expects to be passed two things when it is constructed:
+//
+//  1. The express request object.
+//  2. The express response object.
+//
+// The `requestAware.router` grade does this for you.
 //
 // By default this object is created with a built-in timeout, and will respond with a timeout if nothing else occurs.
-// A typical use case in extending this module would be to perform server-side I/O and then respond with the results.
-// Your response must fire an `afterResponseSent` event to avoid the timeout firing.  Typically you would wire a
-// request handler of some kind in to the modules `onCreate` event, at which point you can expect `that.request` and
-// `that.response` to already exist.
+// To prevent this (and to actually provide a meaningful response to the user), you are expected to define a
+// `handleRequest` invoker that does the following:
+//
+//  1. Sends the user a response.
+//  2. Fires an `afterResponseSent` event.  This prevents the timeout and destroys the component.
+//
+// The `sendResponse` function included with this grade takes care of both, so the simplest `handleRequest` invoker
+// can be defined like this:
+//
+// invokers: {
+//   handleRequest: {
+//     func: "{that}.sendResponse",
+//     args: [ 200, "I am happy to hear from you whatever you have to say." ]
+//   }
+// }
 //
 // For an example of how this can be used, check out the tests included with this package.
 
@@ -23,6 +38,7 @@ var fluid     = fluid || require("infusion");
 var gpii      = fluid.registerNamespace("gpii");
 fluid.registerNamespace("gpii.express.requestAware");
 
+// TODO:  Convert this to use JSON Schema validation when available: https://issues.gpii.net/browse/CTR-161
 gpii.express.requestAware.checkRequirements = function (that) {
     if (!that.options) {
         fluid.fail("Cannot instantiate a 'requestAware' component without the required options...");
@@ -48,9 +64,8 @@ gpii.express.requestAware.clearTimeout = function (that) {
     }
 };
 
-
 gpii.express.requestAware.sendTimeoutResponse = function (that) {
-    that.sendResponse(500, { ok: false, message: "Request aware component timed out before it could respond sensibly." });
+    that.sendResponse("500", { ok: false, message: "Request aware component timed out before it could respond sensibly." });
 };
 
 // Convenience function (with accompanying invoker) to ensure that the `afterResponseSent` event is fired.
@@ -65,7 +80,7 @@ gpii.express.requestAware.sendResponse = function (that, statusCode, body) {
 
 fluid.defaults("gpii.express.requestAware", {
     gradeNames: ["fluid.eventedComponent", "autoInit"],
-    timeout: 5000, // All operations must be completed in `options.timeout` milliseconds, or we will send a timeout response and destroy ourselves.
+    timeout:    5000, // All operations must be completed in `options.timeout` milliseconds, or we will send a timeout response and destroy ourselves.
     mergePolicy: {
         "request":  "nomerge",
         "response": "nomerge"
@@ -87,6 +102,9 @@ fluid.defaults("gpii.express.requestAware", {
             funcName: "gpii.express.requestAware.setTimeout",
             args:     ["{that}"]
         },
+        "onCreate.handleRequest": {
+            func: "{that}.handleRequest"
+        },
         "afterResponseSent.destroy": {
             func: "{that}.destroy"
         },
@@ -103,6 +121,10 @@ fluid.defaults("gpii.express.requestAware", {
         sendTimeoutResponse: {
             funcName: "gpii.express.requestAware.sendTimeoutResponse",
             args:     ["{that}"]
+        },
+        handleRequest: {
+            funcName: "fluid.fail",
+            args:     ["You must override the handleRequest invoker to use this grade."]
         }
     }
 });

--- a/src/js/requestAwareRouter.js
+++ b/src/js/requestAwareRouter.js
@@ -5,9 +5,17 @@
 //
 // If you would like to pass in additional options to the requestAware grade, add an option like the following:
 //
-// `dynamicComponents: { requestHandler: { custom: "value" } }`
+// `dynamicComponents: { requestHandler: { options: { custom: "value" } } }`
 //
-// Those options will be merged with the defaults as expected.
+// Options that already exist when the router is created will be merged with the defaults as expected.  This approach
+// will not work for dynamic values such as model or member variables.
+//
+// For dynamic values, you will need to use an IoC reference from within your `requestAware` grade's definition, as in:
+//
+// fluid.defaults("my.requestAware", {
+//   gradeNames: ["gpii.express.requestAware", "autoInit"],
+//   foo: "{gpii.express.requestAware.router}.foo
+// }
 
 "use strict";
 var fluid     = fluid || require("infusion");

--- a/tests/js/contentAware/contentAware-caseholder.js
+++ b/tests/js/contentAware/contentAware-caseholder.js
@@ -19,6 +19,11 @@ gpii.express.tests.contentAware.caseHolder.verifyResponse = function (response, 
 // Wire in an instance of kettle.requests.request.http for each test and wire the check to its onError or onSuccess event
 fluid.defaults("gpii.express.tests.contentAware.caseHolder", {
     gradeNames: ["autoInit", "fluid.test.testCaseHolder"],
+    expected: {
+        "default": "This is the default response.",
+        text:      "This is the text response.",
+        json:      "This is a JSON response." // Our dummy handler isn't actually sending JSON.
+    },
     mergePolicy: {
         rawModules:    "noexpand",
         sequenceStart: "noexpand"
@@ -49,7 +54,7 @@ fluid.defaults("gpii.express.tests.contentAware.caseHolder", {
                         {
                             listener: "gpii.express.tests.contentAware.caseHolder.verifyResponse",
                             event:    "{defaultRequest}.events.onComplete",
-                            args:     ["{defaultRequest}.nativeResponse", "{arguments}.0", "default"]
+                            args:     ["{defaultRequest}.nativeResponse", "{arguments}.0", "{testCaseHolder}.options.expected.default"]
                         },
                         {
                             func: "{jsonRequest}.send"
@@ -66,7 +71,7 @@ fluid.defaults("gpii.express.tests.contentAware.caseHolder", {
                         {
                             listener: "gpii.express.tests.contentAware.caseHolder.verifyResponse",
                             event:    "{jsonRequest}.events.onComplete",
-                            args:     ["{jsonRequest}.nativeResponse", "{arguments}.0", "json"]
+                            args:     ["{jsonRequest}.nativeResponse", "{arguments}.0", "{testCaseHolder}.options.expected.json"]
                         }
                     ]
                 },
@@ -80,7 +85,7 @@ fluid.defaults("gpii.express.tests.contentAware.caseHolder", {
                         {
                             listener: "gpii.express.tests.contentAware.caseHolder.verifyResponse",
                             event:    "{textRequest}.events.onComplete",
-                            args:     ["{textRequest}.nativeResponse", "{arguments}.0", "text"]
+                            args:     ["{textRequest}.nativeResponse", "{arguments}.0", "{testCaseHolder}.options.expected.text"]
                         }
                     ]
                 }

--- a/tests/js/contentAware/contentAware-caseholder.js
+++ b/tests/js/contentAware/contentAware-caseholder.js
@@ -1,0 +1,122 @@
+/* Tests for the "express" and "router" module */
+"use strict";
+var fluid        = fluid || require("infusion");
+var gpii         = fluid.registerNamespace("gpii");
+var jqUnit       = require("jqUnit");
+
+require("../lib/test-helpers");
+
+fluid.registerNamespace("gpii.express.tests.contentAware.caseHolder");
+
+fluid.setLogging(true);
+
+
+gpii.express.tests.contentAware.caseHolder.verifyResponse = function (response, body, expected) {
+    gpii.express.tests.helpers.isSaneResponse(jqUnit, response, body, 200);
+    jqUnit.assertEquals("The body should be as expected...", expected, body);
+};
+
+// Wire in an instance of kettle.requests.request.http for each test and wire the check to its onError or onSuccess event
+fluid.defaults("gpii.express.tests.contentAware.caseHolder", {
+    gradeNames: ["autoInit", "fluid.test.testCaseHolder"],
+    mergePolicy: {
+        rawModules:    "noexpand",
+        sequenceStart: "noexpand"
+    },
+    moduleSource: {
+        funcName: "gpii.express.tests.helpers.addRequiredSequences",
+        args:     ["{that}.options.sequenceStart", "{that}.options.rawModules"]
+    },
+    sequenceStart: [
+        { // This sequence point is required because of a QUnit bug - it defers the start of sequence by 13ms "to avoid any current callbacks" in its words
+            func: "{testEnvironment}.events.constructServer.fire"
+        },
+        {
+            listener: "fluid.identity",
+            event: "{testEnvironment}.events.onStarted"
+        }
+    ],
+    rawModules: [
+        {
+            tests: [
+                {
+                    name: "Testing with no accepts headers...",
+                    type: "test",
+                    sequence: [
+                        {
+                            func: "{defaultRequest}.send"
+                        },
+                        {
+                            listener: "gpii.express.tests.contentAware.caseHolder.verifyResponse",
+                            event:    "{defaultRequest}.events.onComplete",
+                            args:     ["{defaultRequest}.nativeResponse", "{arguments}.0", "default"]
+                        },
+                        {
+                            func: "{jsonRequest}.send"
+                        }
+                    ]
+                },
+                {
+                    name: "Testing with application/json...",
+                    type: "test",
+                    sequence: [
+                        {
+                            func: "{jsonRequest}.send"
+                        },
+                        {
+                            listener: "gpii.express.tests.contentAware.caseHolder.verifyResponse",
+                            event:    "{jsonRequest}.events.onComplete",
+                            args:     ["{jsonRequest}.nativeResponse", "{arguments}.0", "json"]
+                        }
+                    ]
+                },
+                {
+                    name: "Testing with text/html...",
+                    type: "test",
+                    sequence: [
+                        {
+                            func: "{textRequest}.send"
+                        },
+                        {
+                            listener: "gpii.express.tests.contentAware.caseHolder.verifyResponse",
+                            event:    "{textRequest}.events.onComplete",
+                            args:     ["{textRequest}.nativeResponse", "{arguments}.0", "text"]
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    components: {
+        cookieJar: {
+            type: "kettle.test.cookieJar"
+        },
+        defaultRequest: {
+            type: "kettle.test.request.http",
+            options: {
+                path:    "{testEnvironment}.options.baseUrl",
+                port:    "{testEnvironment}.options.port"
+            }
+        },
+        jsonRequest: {
+            type: "kettle.test.request.http",
+            options: {
+                path:    "{testEnvironment}.options.baseUrl",
+                port:    "{testEnvironment}.options.port",
+                headers: {
+                    accept: "application/json"
+                }
+            }
+        },
+        textRequest: {
+            type: "kettle.test.request.http",
+            options: {
+                path:    "{testEnvironment}.options.baseUrl",
+                port:    "{testEnvironment}.options.port",
+                headers: {
+                    accept: "text/html"
+                }
+            }
+        }
+    }
+});

--- a/tests/js/contentAware/contentAware-tests.js
+++ b/tests/js/contentAware/contentAware-tests.js
@@ -29,7 +29,6 @@ fluid.defaults("gpii.express.tests.contentAware.contentSpecificRouter.request", 
 
 fluid.defaults("gpii.express.tests.contentAware.contentSpecificRouter", {
     gradeNames:         ["gpii.express.requestAware.router", "autoInit"],
-    path:               "/gibberish",
     requestAwareGrades: ["gpii.express.tests.contentAware.contentSpecificRouter.request"]
 });
 

--- a/tests/js/contentAware/contentAware-tests.js
+++ b/tests/js/contentAware/contentAware-tests.js
@@ -11,50 +11,85 @@ require("./includes.js");
 
 var viewDir    = path.resolve(__dirname, "./views");
 
+fluid.registerNamespace("gpii.express.tests.contentAware.contentSpecificRouter.request");
+gpii.express.tests.contentAware.contentSpecificRouter.request.handleRequest = function (that) {
+    that.sendResponse(that.options.statusCode, that.options.body);
+};
 
-fluid.registerNamespace("gpii.express.tests.contentAware.request");
-
-fluid.defaults("gpii.express.tests.contentAware.request", {
-    gradeNames: ["gpii.express.contentAware.request"],
-    messages: {
-        "default": "default",
-        json:      "json",
-        text:      "text"
-    },
-    handlers: {
-        "default": {
-            contentType: "default",
-            handler:     "{that}.handleDefault"
-        },
-        json: {
-            contentType: "application/json",
-            handler:     "{that}.handleJson"
-        },
-        text: {
-            contentType: "text/html",
-            handler:     "{that}.handleText"
-        }
-    },
+fluid.defaults("gpii.express.tests.contentAware.contentSpecificRouter.request", {
+    gradeNames: ["gpii.express.requestAware", "autoInit"],
     invokers: {
-        handleDefault: {
-            funcName: "gpii.express.requestAware.sendResponse",
-            args:     ["{that}", 200, "{that}.options.messages.default"]
-        },
-        handleText: {
-            funcName: "gpii.express.requestAware.sendResponse",
-            args:     ["{that}", 200, "{that}.options.messages.text"]
-        },
-        handleJson: {
-            funcName: "gpii.express.requestAware.sendResponse",
-            args:     ["{that}", 200, "{that}.options.messages.json"]
+        handleRequest: {
+            funcName: "gpii.express.tests.contentAware.contentSpecificRouter.request.handleRequest",
+            args:     ["{that}"]
         }
     }
 });
 
 
+fluid.defaults("gpii.express.tests.contentAware.contentSpecificRouter", {
+    gradeNames:         ["gpii.express.requestAware.router", "autoInit"],
+    path:               "/gibberish",
+    requestAwareGrades: ["gpii.express.tests.contentAware.contentSpecificRouter.request"]
+});
+
 fluid.defaults("gpii.express.tests.contentAware.router", {
     gradeNames:         ["gpii.express.contentAware.router", "autoInit"],
-    requestAwareGrades: ["gpii.express.tests.contentAware.request"]
+    handlers: {
+        "default": {
+            contentType: "default",
+            handler:     "{handleDefault}"
+        },
+        json: {
+            contentType: "application/json",
+            handler:     "{handleJson}"
+        },
+        text: {
+            contentType: "text/html",
+            handler:     "{handleText}"
+        }
+    },
+    components: {
+        handleDefault: {
+            type: "gpii.express.tests.contentAware.contentSpecificRouter",
+            options: {
+                dynamicComponents: {
+                    requestHandler: {
+                        options: {
+                            statusCode: 200,
+                            body:       "This is the default response."
+                        }
+                    }
+                }
+            }
+        },
+        handleText: {
+            type: "gpii.express.tests.contentAware.contentSpecificRouter",
+            options: {
+                dynamicComponents: {
+                    requestHandler: {
+                        options: {
+                            statusCode: 200,
+                            body:       "This is the text response."
+                        }
+                    }
+                }
+            }
+        },
+        handleJson: {
+            type: "gpii.express.tests.contentAware.contentSpecificRouter",
+            options: {
+                dynamicComponents: {
+                    requestHandler: {
+                        options: {
+                            statusCode: 200,
+                            body:       "This is a JSON response."
+                        }
+                    }
+                }
+            }
+        }
+    }
 });
 
 fluid.defaults("gpii.express.tests.contentAware.testEnvironment", {

--- a/tests/js/contentAware/contentAware-tests.js
+++ b/tests/js/contentAware/contentAware-tests.js
@@ -1,0 +1,102 @@
+/* Tests for the "express" and "router" module */
+"use strict";
+var fluid        = fluid || require("infusion");
+var gpii         = fluid.registerNamespace("gpii");
+
+fluid.setLogging(true);
+
+var path         = require("path");
+
+require("./includes.js");
+
+var viewDir    = path.resolve(__dirname, "./views");
+
+
+fluid.registerNamespace("gpii.express.tests.contentAware.request");
+
+fluid.defaults("gpii.express.tests.contentAware.request", {
+    gradeNames: ["gpii.express.contentAware.request"],
+    messages: {
+        "default": "default",
+        json:      "json",
+        text:      "text"
+    },
+    handlers: {
+        "default": {
+            contentType: "default",
+            handler:     "{that}.handleDefault"
+        },
+        json: {
+            contentType: "application/json",
+            handler:     "{that}.handleJson"
+        },
+        text: {
+            contentType: "text/html",
+            handler:     "{that}.handleText"
+        }
+    },
+    invokers: {
+        handleDefault: {
+            funcName: "gpii.express.requestAware.sendResponse",
+            args:     ["{that}", 200, "{that}.options.messages.default"]
+        },
+        handleText: {
+            funcName: "gpii.express.requestAware.sendResponse",
+            args:     ["{that}", 200, "{that}.options.messages.text"]
+        },
+        handleJson: {
+            funcName: "gpii.express.requestAware.sendResponse",
+            args:     ["{that}", 200, "{that}.options.messages.json"]
+        }
+    }
+});
+
+
+fluid.defaults("gpii.express.tests.contentAware.router", {
+    gradeNames:         ["gpii.express.contentAware.router", "autoInit"],
+    requestAwareGrades: ["gpii.express.tests.contentAware.request"]
+});
+
+fluid.defaults("gpii.express.tests.contentAware.testEnvironment", {
+    gradeNames: ["fluid.test.testEnvironment", "autoInit"],
+    port:   7533,
+    baseUrl: "http://localhost:7533/",
+    events: {
+        constructServer: null,
+        onStarted: null
+    },
+    components: {
+        express: {       // instance of component under test
+            createOnEvent: "constructServer",
+            type: "gpii.express",
+            options: {
+                events: {
+                    onStarted: "{testEnvironment}.events.onStarted"
+                },
+                config: {
+                    express: {
+                        port: "{testEnvironment}.options.port",
+                        baseUrl: "{testEnvironment}.options.baseUrl",
+                        views:   viewDir,
+                        session: {
+                            secret: "Printer, printer take a hint-ter."
+                        }
+                    }
+                },
+                components: {
+                    router: {
+                        type: "gpii.express.tests.contentAware.router",
+                        options: {
+                            path: "/"
+                        }
+                    }
+                }
+            }
+        },
+        testCaseHolder: {
+            type: "gpii.express.tests.contentAware.caseHolder"
+        }
+    }
+});
+
+gpii.express.tests.contentAware.testEnvironment();

--- a/tests/js/contentAware/includes.js
+++ b/tests/js/contentAware/includes.js
@@ -1,0 +1,11 @@
+"use strict";
+
+// The base classes we are testing
+require("../../../index.js");
+
+// Our test fixtures and test cases
+require("./contentAware-caseholder");
+
+// We use just the request-handling bits of the kettle stack in our tests, but we include the whole thing to pick up the base grades
+require("../../../node_modules/kettle");
+require("../../../node_modules/kettle/lib/test/KettleTestUtils");

--- a/tests/js/requestAware/requestAware-caseholder.js
+++ b/tests/js/requestAware/requestAware-caseholder.js
@@ -22,8 +22,17 @@ gpii.express.tests.requestAware.caseHolder.testRequestAwareTimeoutResponse = fun
 
 // Look at two sequential requests and confirm that they are different.
 gpii.express.tests.requestAware.caseHolder.testRequestAwareIntegrity = function (firstResponseString, secondResponseString) {
-    var firstResponseBody  = JSON.parse(firstResponseString);
-    var secondResponseBody = JSON.parse(secondResponseString);
+    // If we can evolve the response into JSON, we do.
+    var firstResponseBody  = firstResponseString;
+    var secondResponseBody = secondResponseString;
+    try {
+        firstResponseBody  = JSON.parse(firstResponseString);
+        secondResponseBody = JSON.parse(secondResponseString);
+    }
+    catch (e) {
+        // Do nothing
+    }
+
     jqUnit.assertDeepNeq("Two sequential requests should be different.", firstResponseBody, secondResponseBody);
 };
 
@@ -56,6 +65,28 @@ fluid.defaults("gpii.express.tests.requestAware.caseHolder", {
                     type: "test",
                     sequence: [
                         {
+                            func: "{requestAwareInstrumentedRequest}.send"
+                        },
+                        {
+                            listener: "gpii.express.tests.requestAware.caseHolder.testRequestAwareDelayedResponse",
+                            event:    "{requestAwareInstrumentedRequest}.events.onComplete",
+                            args:     ["{requestAwareInstrumentedRequest}", "{requestAwareInstrumentedRequest}.nativeResponse", "{arguments}.0"]
+                        },
+                        {
+                            func: "{requestAwareSecondInstrumentedRequest}.send"
+                        },
+                        {
+                            listener: "gpii.express.tests.requestAware.caseHolder.testRequestAwareIntegrity",
+                            event:    "{requestAwareSecondInstrumentedRequest}.events.onComplete",
+                            args:     ["{requestAwareInstrumentedRequest}.body", "{arguments}.0"]
+                        }
+                    ]
+                },
+                {
+                    name: "Testing a slow but responsive 'request aware' component...",
+                    type: "test",
+                    sequence: [
+                        {
                             func: "{requestAwareDelayedRequest}.send"
                         },
                         {
@@ -74,7 +105,7 @@ fluid.defaults("gpii.express.tests.requestAware.caseHolder", {
                     ]
                 },
                 {
-                    name: "Testing a basic 'request aware' component...",
+                    name: "Testing a nonresponsive 'request aware' component...",
                     type: "test",
                     sequence: [
                         {
@@ -93,6 +124,32 @@ fluid.defaults("gpii.express.tests.requestAware.caseHolder", {
     components: {
         cookieJar: {
             type: "kettle.test.cookieJar"
+        },
+        requestAwareInstrumentedRequest: {
+            type: "kettle.test.request.http",
+            options: {
+                path: {
+                    expander: {
+                        funcName: "gpii.express.tests.helpers.assembleUrl",
+                        args:     ["{testEnvironment}.options.baseUrl", "/instrumented"]
+                    }
+                },
+                port: "{testEnvironment}.options.port",
+                method: "GET"
+            }
+        },
+        requestAwareSecondInstrumentedRequest: {
+            type: "kettle.test.request.http",
+            options: {
+                path: {
+                    expander: {
+                        funcName: "gpii.express.tests.helpers.assembleUrl",
+                        args:     ["{testEnvironment}.options.baseUrl", "/instrumented"]
+                    }
+                },
+                port: "{testEnvironment}.options.port",
+                method: "GET"
+            }
         },
         requestAwareDelayedRequest: {
             type: "kettle.test.request.http",


### PR DESCRIPTION
See [GPII-1259](https://issues.gpii.net/browse/GPII-1259) for details.