### PR TITLE
GPII-1279:  Fixed problems with static middleware.

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Fluid components to model an express server and associated router modules.",
   "main":        "",
   "scripts": {
-    "test":        "src/tests/all-tests.js",
+    "test":        "tests/all-tests.js",
     "postinstall": "grunt dedupe-infusion"
   },
   "repository": {

--- a/src/js/static.js
+++ b/src/js/static.js
@@ -22,8 +22,8 @@ gpii.express.router["static"].init = function (that) {
     that.staticHandler = express["static"](that.options.content);
 };
 
-gpii.express.router["static"].route = function (that, req, res) {
-    that.staticHandler(req, res);
+gpii.express.router["static"].route = function (that, req, res, next) {
+    that.staticHandler(req, res, next);
 };
 
 fluid.defaults("gpii.express.router.static", {
@@ -39,7 +39,7 @@ fluid.defaults("gpii.express.router.static", {
     invokers: {
         route: {
             "funcName": "gpii.express.router.static.route",
-            "args":     ["{that}", "{arguments}.0", "{arguments}.1"]
+            "args":     ["{that}", "{arguments}.0", "{arguments}.1", "{arguments}.2"]
         }
     }
 });

--- a/tests/js/router/router-tests.js
+++ b/tests/js/router/router-tests.js
@@ -40,6 +40,14 @@ fluid.defaults("gpii.express.tests.router.testEnvironment", {
                     }
                 },
                 components: {
+                    // This should be loaded first to detect regressions on GPII-1279
+                    staticRouter: {
+                        type: "gpii.express.router.static",
+                        options: {
+                            path:    "/",
+                            content: contentDir
+                        }
+                    },
                     hello: {
                         type: "gpii.express.tests.router.hello",
                         options: {
@@ -90,13 +98,6 @@ fluid.defaults("gpii.express.tests.router.testEnvironment", {
                         type: "gpii.express.tests.router.params",
                         options: {
                             path: "/params/:myVar"
-                        }
-                    },
-                    staticRouter: {
-                        type: "gpii.express.router.static",
-                        options: {
-                            path:    "/",
-                            content: contentDir
                         }
                     }
                 }


### PR DESCRIPTION
There was a bug that would cause the static middleware to throw errors.  See [GPII-1279](https://issues.gpii.net/browse/GPII-1279) for details.