### PR TITLE
GPII-1647: Create `headerSetter` middleware...

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -18,6 +18,4 @@ module.exports = function (grunt) {
     grunt.loadNpmTasks("grunt-contrib-jshint");
     grunt.loadNpmTasks("grunt-jsonlint");
     grunt.loadNpmTasks("grunt-shell");
-    grunt.loadNpmTasks("grunt-gpii");
-
 };

--- a/docs/headerMiddleware.md
+++ b/docs/headerMiddleware.md
@@ -1,0 +1,165 @@
+# gpii.express.middleware.headerSetter
+
+This component sets one or more [HTTP response headers](https://www.w3.org/Protocols/rfc2616/rfc2616-sec6.html#sec6.2)
+based on the contents of `options.headers` (see below).
+
+## Component Options
+
+The following component configuration options are supported:
+
+| Option    | Type       | Description |
+| --------- | ---------- | ----------- |
+| `headers` | `{Object}` | A map of options including details on what field name and value to set (see below).  This option is not merged, the rightmost grade that defines this option will win. See [the options merging docs](http://docs.fluidproject.org/infusion/development/OptionsMerging.html#structure-of-the-merge-policy-object) for details. |
+
+Individual headers are defined as in the following example:
+
+    headers: {
+        static: {
+            fieldName: "Access-Control-Allow-Origin",
+            template:   "*"
+        },
+        dynamic: {
+            fieldName: "Content-Type",
+            template: "%var",
+            dataRules: {
+                var: "request.query.var"
+            }
+        }
+    }
+
+The supported fields are as follows:
+
+| Field       | Type       | Description |
+| ----------- | ---------- | ----------- |
+| `fieldName` | `{String}` | The string value of the header to set, for example `Set-Cookie` or `Content-Type`. |
+| `template`  | `{String}` | A [string template](http://docs.fluidproject.org/infusion/development/tutorial-usingStringTemplates/UsingStringTemplates.html) representing the header value. |
+| `dataRules` | `{Object}` | [Model transformation rules](http://docs.fluidproject.org/infusion/development/ModelTransformationAPI.html) that control what data will be combined with `template` (see below) |
+
+The simplest header definition looks something like the following
+
+    headers: {
+        static: {
+            fieldName: "Access-Control-Allow-Origin",
+            template:   "*"
+        }
+    }
+
+Note that the template has no variables (which would look something like `%var`).  As a result, the literal value `*` is
+set.  In this case, no data is interpolated, so `dataRules` is ignored and can be safely omitted.
+
+A full definition looks something like the following:
+
+    headers: {
+        dynamic: {
+            fieldName: "Content-Type",
+            template: "%var",
+            dataRules: {
+                var: "request.query.var"
+            }
+        }
+    }
+
+If we were accessing a URL like `http://my.site.com/path/to/router?var=application%2Fjson`, this component would set
+the `Content-Type` header to `application/json`.
+
+The rules defined in `dataRules` have access to `that`, the component itself, and `request`, the
+[Express request object](expressjs.com/en/api.html#req).  In the example above, we have pulled query data from the
+`request` object.  We could just has easily have read a model variable from our component, or an option from our
+component.  Here is an example illustrating a few possibilities:
+
+    headers: {
+        deleteCookie: {
+            fieldName: "Set-Cookie",
+            template:  "existingCookie=deleted; Expires=Thu, 01-Jan-1970 00:00:01 GMT"
+        },
+        setModelCookie: {
+            fieldName: "Set-Cookie",
+            template:  "%cookieName=%cookieValue",
+            dataRules: {
+                cookieName:  "that.model.cookie.name",
+                cookieValue: "that.model.cookie.value"
+            }
+        },
+        refresh: {
+            fieldName: "Refresh",
+            template: "%seconds; url=%url",
+            dataRules: {
+                seconds: { literalValue: 5 },
+                url:     "that.options.refreshUrl"
+            }
+        }
+    }
+
+With those rules, this component would:
+
+1. Set the `Set-Coookie` header to `{that.model.cookie.name}={that.model.cookie.value}`
+2. Set the `Refresh` header to `5; url={that.options.refreshUrl}`
+
+Note that the hard-coded value of `5` in the `refresh` example is set in a `dataRules` block using `literalValue`.  You
+can also set static values in the `template` value itself, as illustrated in the `deleteCookie` example.
+
+## Invokers
+
+### `{middleware}.middleware(req, res, next)`
+
+* `req`: The [request object](http://expressjs.com/en/api.html#req) provided by Express, which wraps node's [`http.incomingMessage`](https://nodejs.org/api/http.html#http_class_http_incomingmessage).
+* `res`: The [response object](http://expressjs.com/en/api.html#res) provided by Express, which wraps node's [`http.ServerResponse`](https://nodejs.org/api/http.html#http_class_http_serverresponse).
+* `next`: The next Express middleware or router function in the chain.
+* Returns: Nothing.
+
+This invoker fulfills the standard contract for a `gpii.express.middleware` component.  It uses `fluid.model.transformWithRules`
+to generate data that is combined with `template` using `fluid.stringTemplate` (see above).
+
+# Using this grade
+
+This grade can only do its job when it is added as a child component of either a `gpii.express` or `gpii.express.router`
+instance.  Here's an example of adding a single header to all responses send from a `gpii.express` instance:
+
+    gpii.express({
+        path: 8080,
+        components: {
+            headerSetter: {
+                type: "gpii.express.middleware.headerSetter",
+                options: {
+                    headers: {
+                        server: {
+                            fieldName: "Server",
+                            template:  "Custom gpii-express Server/1.0.0"
+                        }
+                    }
+                }
+            }
+            // TODO:  add at least one actual router here
+        }
+    });
+
+Note that as with any other `gpii.express.middleware`, this component will only add headers for conversations it's
+involved in.  When you add an instance of this component as a component of `gpii.express`, it will be allowed to modify
+every response for the whole instance, unless other middleware steps in and interrupts the conversation before it gets the chance.
+
+Here's an example of how this component can be used with a `gpii.express.router` instance:
+
+    gpii.express({
+        path: 8081,
+        components: {
+            staticRouter: {
+                type: "gpii.express.router.static",
+                options: {
+                    content: "%my-package/src",
+                    components: {
+                        headerSetter: {
+                            type: "gpii.express.middleware.headerSetter",
+                            options: {
+                                headers: {
+                                    cors: {
+                                        fieldName: "Access-Control-Allow-Origin",
+                                        template:  "*"
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    });

--- a/index.js
+++ b/index.js
@@ -22,6 +22,9 @@ require("./src/js/configholder");
 // `gpii.express.middleware`, the base grade for all middleware components
 require("./src/js/middleware");
 
+// `gpii.express.middleware.headerSetter`, middleware to set HTTP response headers
+require("./src/js/headerMiddleware");
+
 // A middleware component to add support for cookies
 require("./src/js/cookieparser");
 

--- a/package.json
+++ b/package.json
@@ -1,14 +1,10 @@
 {
   "name":        "gpii-express",
-  "version":     "0.0.0",
+  "version":     "1.0.0",
   "description": "Fluid components to model an express server and associated router modules.",
-  "main":        "",
+  "main":        "index.js",
   "scripts": {
     "test":        "node tests/all-tests.js"
-  },
-  "repository": {
-    "type": "git",
-    "url":  "https://github.com/the-t-in-rtf/gpii-express"
   },
   "author":     "Tony Atkins <tony@raisingthefloor.org>",
   "license":    "BSD-3-Clause",

--- a/src/js/handler.js
+++ b/src/js/handler.js
@@ -93,7 +93,7 @@ fluid.defaults("gpii.express.handler.base", {
     invokers: {
         sendResponse: {
             funcName: "gpii.express.handler.sendResponse",
-            args:     ["{that}", "{arguments}.0", "{arguments}.1", "{arguments}.2"] // request, statusCode, body
+            args:     ["{that}", "{arguments}.0", "{arguments}.1", "{arguments}.2"] // response, statusCode, body
         }
     }
 });

--- a/src/js/handler.js
+++ b/src/js/handler.js
@@ -78,30 +78,12 @@ gpii.express.handler.sendResponse = function (that, response, statusCode, body) 
     that.events.afterResponseSent.fire(that);
 };
 
-
-// A base grade for use in contexts where request isolation is handled without creating dynamic components.
-//
-// This component has the `afterResponseSent` event handler so that it can use the standard `sendResponse` function
-// above. It does not require you to implement a `handleRequest` function, you can use the `sendResponse` invoker
-// directly.
-//
-fluid.defaults("gpii.express.handler.base", {
+fluid.defaults("gpii.express.handler", {
     gradeNames: ["fluid.component"],
+    timeout:    5000, // All operations must be completed in `options.timeout` milliseconds, or we will send a timeout response and destroy ourselves.
     events: {
         afterResponseSent: null
     },
-    invokers: {
-        sendResponse: {
-            funcName: "gpii.express.handler.sendResponse",
-            args:     ["{that}", "{arguments}.0", "{arguments}.1", "{arguments}.2"] // response, statusCode, body
-        }
-    }
-});
-
-// The default implementation, which is designed to be "single use" and to be dynamically created per request.
-fluid.defaults("gpii.express.handler", {
-    gradeNames: ["gpii.express.handler.base"],
-    timeout:    5000, // All operations must be completed in `options.timeout` milliseconds, or we will send a timeout response and destroy ourselves.
     mergePolicy: {
         "request":  "nomerge",
         "response": "nomerge"

--- a/src/js/headerMiddleware.js
+++ b/src/js/headerMiddleware.js
@@ -25,7 +25,7 @@ fluid.registerNamespace("gpii.express.middleware.headerSetter");
  */
 gpii.express.middleware.headerSetter.addHeaders = function (that, req, res, next) {
     fluid.each(that.options.headers, function (headerOptions) {
-        var templateData = fluid.model.transformWithRules({ that: that, request: req }, headerOptions.dataRules)
+        var templateData = fluid.model.transformWithRules({ that: that, request: req }, headerOptions.dataRules);
         var fieldValue = fluid.stringTemplate(headerOptions.template, templateData);
 
         res.setHeader(headerOptions.fieldName, fieldValue);

--- a/src/js/headerMiddleware.js
+++ b/src/js/headerMiddleware.js
@@ -1,0 +1,50 @@
+/*
+
+    A `gpii.express.middleware` component that sets one or more HTTP headers based on the content of `options.headers`.
+
+    See the documentation for more details:
+
+    https://github.com/the-t-in-rtf/gpii-express/blob/GPII-1647/docs/headerMiddleware.md
+
+ */
+"use strict";
+var fluid = require("infusion");
+var gpii  = fluid.registerNamespace("gpii");
+
+fluid.registerNamespace("gpii.express.middleware.headerSetter");
+
+/**
+ *
+ * @param that {Object} The middleware component itself.
+ * @param req {Object} The Express request object.
+ * @param res {Object} The Express response object.
+ * @param next {Function} The function to be executed next in the middleware chain.
+ *
+ * A middleware function that adds one or more headers before launching the next middleware function in the chain.
+ *
+ */
+gpii.express.middleware.headerSetter.addHeaders = function (that, req, res, next) {
+    fluid.each(that.options.headers, function (headerOptions) {
+        var templateData = fluid.model.transformWithRules({ that: that, request: req }, headerOptions.dataRules)
+        var fieldValue = fluid.stringTemplate(headerOptions.template, templateData);
+
+        res.setHeader(headerOptions.fieldName, fieldValue);
+    });
+
+    next();
+};
+
+
+fluid.defaults("gpii.express.middleware.headerSetter", {
+    gradeNames: ["gpii.express.middleware"],
+    mergePolicy: {
+        "headers": "nomerge"
+    },
+    invokers: {
+        middleware: {
+            funcName: "gpii.express.middleware.headerSetter.addHeaders",
+            args:     ["{that}", "{arguments}.0", "{arguments}.1", "{arguments}.2"] // req, res, next
+        }
+    }
+
+});

--- a/src/js/requestAwareRouter.js
+++ b/src/js/requestAwareRouter.js
@@ -20,8 +20,10 @@
 "use strict";
 var fluid = require("infusion");
 
-fluid.defaults("gpii.express.requestAware.router", {
-    gradeNames: ["gpii.express.router"],
+// A base grade to allow the dynamic request handling infrastructure to be used in things that are not routers
+// (such as the `schemaMiddleware` grade in `gpii-json-schema`.
+fluid.defaults("gpii.express.requestAware.base", {
+    gradeNames: ["fluid.component"],
     timeout: 5000, // The default timeout we will pass to whatever grade we instantiate.
     distributeOptions: [
         {
@@ -46,7 +48,11 @@ fluid.defaults("gpii.express.requestAware.router", {
                 response:   "{arguments}.1"
             }
         }
-    },
+    }
+});
+
+fluid.defaults("gpii.express.requestAware.router", {
+    gradeNames: ["gpii.express.requestAware.base", "gpii.express.router"],
     invokers: {
         route: {
             func: "{that}.events.onRequest.fire",

--- a/tests/all-tests.js
+++ b/tests/all-tests.js
@@ -3,6 +3,7 @@ require("./js/handler/handler-tests");
 require("./js/helpers/helpers-tests");
 require("./js/method/method-isolation-tests");
 require("./js/middleware/middleware-tests");
+require("./js/headerMiddleware/headerMiddleware-tests");
 require("./js/requestAware/requestAware-tests");
 require("./js/router/router-tests");
 require("./js/router/static/static-tests");

--- a/tests/js/headerMiddleware/headerMiddleware-caseholder.js
+++ b/tests/js/headerMiddleware/headerMiddleware-caseholder.js
@@ -1,0 +1,91 @@
+/* Tests for the "express" and "router" module */
+"use strict";
+var fluid  = require("infusion");
+var gpii   = fluid.registerNamespace("gpii");
+var jqUnit = require("node-jqunit");
+
+fluid.registerNamespace("gpii.express.tests.headerMiddleware.caseHolder");
+
+gpii.express.tests.headerMiddleware.caseHolder.checkHeader = function (message, response, header, expected) {
+    var headerContent = response.headers[header.toLowerCase()];
+    jqUnit.assertEquals(message, expected, headerContent);
+};
+
+fluid.defaults("gpii.express.tests.headerMiddleware.request", {
+    gradeNames: ["kettle.test.request.http"],
+    method: "GET",
+    endpoint: "hello?variable=set",
+    path: {
+        expander: {
+            funcName: "fluid.stringTemplate",
+            args:     ["%baseUrl%endpoint", { baseUrl: "{testEnvironment}.options.baseUrl", endpoint: "{that}.options.endpoint"}]
+        }
+    },
+    port: "{testEnvironment}.options.port"
+});
+
+// Wire in an instance of kettle.requests.request.http for each test and wire the check to its onError or onSuccess event
+fluid.defaults("gpii.express.tests.headerMiddleware.caseHolder", {
+    gradeNames: ["gpii.express.tests.caseHolder"],
+    rawModules: [
+        {
+            tests: [
+                {
+                    name: "Testing `headerSetter` middleware (with query data)...",
+                    type: "test",
+                    sequence: [
+                        {
+                            func: "{request}.send"
+                        },
+                        {
+                            listener: "gpii.express.tests.headerMiddleware.caseHolder.checkHeader",
+                            event:    "{request}.events.onComplete",
+                            args:    ["A top level query variable should be set correctly...", "{request}.nativeResponse", "Top-Level-Query-Variable", "set"] // message, response, header, expected
+                        },
+                        {
+                            func: "gpii.express.tests.headerMiddleware.caseHolder.checkHeader",
+                            args:    ["A deep query variable should be set correctly...", "{request}.nativeResponse", "Deep-Query-Variable", "set"] // message, response, header, expected
+                        },
+                        {
+                            func: "gpii.express.tests.headerMiddleware.caseHolder.checkHeader",
+                            args:    ["A static template should set a header correctly...", "{request}.nativeResponse", "Static-Template", "static template"] // message, response, header, expected
+                        },
+                        {
+                            func: "gpii.express.tests.headerMiddleware.caseHolder.checkHeader",
+                            args:    ["A rule that uses `literalValue` should set a header correctly...", "{request}.nativeResponse", "Static-Rules", "static rules"] // message, response, header, expected
+                        }
+                    ]
+                },
+                {
+                    name: "Testing `headerSetter` middleware (sans query data)...",
+                    type: "test",
+                    sequence: [
+                        {
+                            func: "{requestSansQueryData}.send"
+                        },
+                        {
+                            listener: "gpii.express.tests.headerMiddleware.caseHolder.checkHeader",
+                            event:    "{requestSansQueryData}.events.onComplete",
+                            args:    ["A top level query variable should be set correctly...", "{requestSansQueryData}.nativeResponse", "Top-Level-Query-Variable", "%variable"] // message, response, header, expected
+                        },
+                        {
+                            func: "gpii.express.tests.headerMiddleware.caseHolder.checkHeader",
+                            args:    ["A deep query variable should be set correctly...", "{requestSansQueryData}.nativeResponse", "Deep-Query-Variable", "%variable"] // message, response, header, expected
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    components: {
+        request: {
+            type: "gpii.express.tests.headerMiddleware.request"
+        },
+        requestSansQueryData: {
+            type: "gpii.express.tests.headerMiddleware.request",
+            options: {
+                endpoint: "hello"
+            }
+        }
+    }
+});

--- a/tests/js/headerMiddleware/headerMiddleware-tests.js
+++ b/tests/js/headerMiddleware/headerMiddleware-tests.js
@@ -1,0 +1,99 @@
+/* Tests for the "middleware" grade and "wrapper" modules for common Express middleware. */
+"use strict";
+var fluid = require("infusion");
+var gpii  = fluid.registerNamespace("gpii");
+
+// Load all of the components to be tested and our test cases
+require("../includes.js");
+
+// We borrow a router from the router tests to help in testing middleware isolation
+require("../router/test-router-hello");
+require("./headerMiddleware-caseholder");
+
+fluid.defaults("gpii.express.tests.headerMiddleware.testEnvironment", {
+    gradeNames: ["fluid.test.testEnvironment"],
+    port:   7531,
+    baseUrl: "http://localhost:7531/",
+    events: {
+        constructServer: null,
+        onStarted: null
+    },
+    components: {
+        express: {
+            createOnEvent: "constructServer",
+            type: "gpii.express",
+            options: {
+                events: {
+                    onStarted: "{testEnvironment}.events.onStarted"
+                },
+                config: {
+                    express: {
+                        port: "{testEnvironment}.options.port",
+                        baseUrl: "{testEnvironment}.options.baseUrl",
+                        views:   "%gpii-express/tests/views",
+                        session: {
+                            secret: "Printer, printer take a hint-ter."
+                        }
+                    }
+                },
+                components: {
+                    topLevelMiddleware: {
+                        type: "gpii.express.middleware.headerSetter",
+                        options: {
+                            headers: {
+                                queryVar: {
+                                    fieldName: "Top-Level-Query-Variable",
+                                    template:  "%variable",
+                                    dataRules: {
+                                        variable: "request.query.variable"
+                                    }
+                                },
+                                staticTemplate: {
+                                    fieldName: "Static-Template",
+                                    template:  "static template",
+                                    // TODO: Make it possible to omit this
+                                    dataRules: {
+
+                                    }
+                                },
+                                staticRules: {
+                                    fieldName: "Static-Rules",
+                                    template:  "%variable",
+                                    dataRules: {
+                                        variable: { literalValue: "static rules"}
+                                    }
+                                }
+                            }
+                        }
+                    },
+                    hello: {
+                        type: "gpii.express.tests.router.hello",
+                        options: {
+                            components: {
+                                deepMiddleware: {
+                                    type: "gpii.express.middleware.headerSetter",
+                                    options: {
+                                        headers: {
+                                            queryVar: {
+                                                fieldName: "Deep-Query-Variable",
+                                                template:  "%variable",
+                                                dataRules: {
+                                                    variable: "request.query.variable"
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        testCaseHolder: {
+            type: "gpii.express.tests.headerMiddleware.caseHolder"
+        }
+    }
+});
+
+gpii.express.tests.headerMiddleware.testEnvironment();


### PR DESCRIPTION
See [GPII-1647](https://issues.gpii.net/browse/GPII-1647) for details.

This work feeds into [the ongoing PR for `gpii-json-schema`](https://github.com/GPII/gpii-json-schema/pull/5), as a derived grade of this component will replace most of the existing "JSON Schema Handler".